### PR TITLE
Add Dockerfile to build an odh image with local manifests

### DIFF
--- a/odh-operator-image/Dockerfile
+++ b/odh-operator-image/Dockerfile
@@ -1,0 +1,6 @@
+ARG version=v0.8.0
+FROM quay.io/opendatahub/opendatahub-operator:${version}
+ARG version
+
+RUN curl -L https://github.com/red-hat-data-services/odh-manifests/tarball/${version} -o /opt/manifests/${version}.tar.gz --create-dirs && \
+    ln -s /opt/manifests/${version}.tar.gz /opt/manifests/odh-manifests.tar.gz


### PR DESCRIPTION
Version of odh is settable via ARG and corresponds to the
base image and manifest tarball to use. Locates the tarball
via a symlink at /manifests/odh-manifests.