### PR TITLE
 Make image a true multistage build

### DIFF
--- a/odh-operator-image/Dockerfile
+++ b/odh-operator-image/Dockerfile
@@ -1,15 +1,13 @@
-ARG operator_ver=0.1.0
-ARG manifest_ver=v0.8.0
+ARG manifest_base=quay.io/modh/odh-manifests
+ARG manifest_ver=0.1.0
+
 ARG operator_base=quay.io/modh/opendatahub-operator
-ARG manifest_url=https://github.com/red-hat-data-services/odh-manifests
+ARG operator_ver=0.1.0
 
+FROM ${manifest_base}:${manifest_ver} as manifests
 FROM ${operator_base}:${operator_ver}
-ARG manifest_ver
-ARG manifest_url
 USER root
-RUN curl -L ${manifest_url}/tarball/${manifest_ver} -o /opt/manifests/${manifest_ver}.tar.gz --create-dirs && \
-    ln -s /opt/manifests/${manifest_ver}.tar.gz /opt/manifests/odh-manifests.tar.gz && \
-    chown 1001:0 /opt/manifests &&\
+COPY --from=manifests /opt/odh-manifests.tar.gz /opt/manifests/
+RUN chown -R 1001:0 /opt/manifests &&\
     chmod -R a+r /opt/manifests
-
 USER 1001


### PR DESCRIPTION
Consume the manifest tarball from an image rather than
curling the manifests from the source repository.