### PR TITLE
fix the contextpath for odh-operator-image in pipeline

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -64,7 +64,7 @@ spec:
         - name: registry_secret
           value: "modh-pusher-secret"
         - name: context_path
-          value: odh-deployer
+          value: odh-operator-image
         - name: dockerfile
           value: Dockerfile
       resources:


### PR DESCRIPTION
fix the contextpath for odh-operator-image in the pipeline
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>